### PR TITLE
Add tile info window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ src/drawable/text.h
 src/drawable/texture.cc
 src/drawable/texture.h
 src/drawable/texture_manager.h
+src/gui/window.cc
+src/gui/window.h
 
 src/input/input.cc
 src/input/input.h

--- a/src/core/screen/screen.cc
+++ b/src/core/screen/screen.cc
@@ -30,12 +30,15 @@ void Screen::Draw() const {
 
 void Screen::CheckButtons() {
   RVector2 mouse_position = GetMousePosition();
-  for (auto& button_static : buttons_static_) {
-    button_static->CheckMouse(mouse_position);
+  bool consumed = false;
+
+  for (auto it = buttons_static_.rbegin(); it != buttons_static_.rend(); ++it) {
+      consumed = (*it)->CheckMouse(mouse_position) || consumed;
   }
+
   RVector2 mouse_position_world = camera_->GetScreenToWorld(mouse_position);
-  for (auto& button : buttons_) {
-    button->CheckMouse(mouse_position_world);
+  for (auto it = buttons_.rbegin(); it != buttons_.rend(); ++it) {
+      consumed = (*it)->CheckMouse(mouse_position_world, !consumed) || consumed;
   }
 }
 
@@ -68,3 +71,4 @@ void Screen::PlaceDrawable(std::shared_ptr<Drawable> drawable, bool is_static) {
 }
 
 } // namespace fow
+

--- a/src/drawable/button/button.cc
+++ b/src/drawable/button/button.cc
@@ -12,16 +12,21 @@ namespace fow {
 Button::Button(RVector2 position, std::function<void()> action_lmb, std::function<void()> action_rmb)
   : Drawable(position), action_lmb_(action_lmb), action_rmb_(action_rmb) {}
 
-void Button::CheckMouse(RVector2 mouse_position) {
-  is_hovered_ = area_.CheckCollision(mouse_position);
-  if (is_hovered_) {
-    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
-      action_lmb_();
+bool Button::CheckMouse(RVector2 mouse_position, bool process_click) {
+        bool handled = false;
+        is_hovered_ = area_.CheckCollision(mouse_position);
+        if (is_hovered_ && process_click) {
+            if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+                action_lmb_();
+                handled = true;
+            }
+            if (IsMouseButtonReleased(MOUSE_BUTTON_RIGHT)) {
+                action_rmb_();
+                handled = true;
+            }
+        }
+            return handled;
+
     }
-    if (IsMouseButtonReleased(MOUSE_BUTTON_RIGHT)) {
-      action_rmb_();
-    }
-  }
-}
 
 } // namespace fow

--- a/src/drawable/button/button.h
+++ b/src/drawable/button/button.h
@@ -13,7 +13,8 @@ class Button : public Drawable {
   public:
   Button(RVector2 position, std::function<void()> action_lmb, std::function<void()> action_rmb);
   virtual ~Button() {};
-  void CheckMouse(RVector2 mouse_position);
+  //void CheckMouse(RVector2 mouse_position);
+  bool CheckMouse(RVector2 mouse_position, bool process_click = true);
 
   RRectangle GetArea() const { return area_; }
   void SetIsSelected(bool is_selected) { is_selected_ = is_selected; }

--- a/src/gui/window.cc
+++ b/src/gui/window.cc
@@ -1,0 +1,49 @@
+#include "window.h"
+
+#include <Color.hpp>
+#include <Text.hpp>
+#include <Vector2.hpp>
+
+#include "../drawable/button/text_button.h"
+#include "../drawable/rectangle.h"
+#include "../drawable/text.h"
+
+namespace fow {
+
+	Window::Window(RVector2 pos, RVector2 size) {
+		InitWindow(pos, size, std::nullopt);
+	}
+
+	Window::Window(RVector2 position, RVector2 size, const RText& text) {
+		InitWindow(position, size, text);
+	}
+
+	void Window::InitWindow(RVector2 pos, RVector2 size,
+		const std::optional<RText>& text) {
+		RColor background_color = RColor::Black().Alpha(0.8f);
+		std::shared_ptr<Rectangle> background
+			= std::make_shared<Rectangle>(pos, size, background_color);
+		drawables_.push_back(background);
+
+		if (text) {
+			std::shared_ptr<Text> window_text = 
+				std::make_shared<Text>(pos + size / 2.f, *text, true);
+			drawables_.push_back(window_text);
+		}
+
+		RVector2 close_pos = pos + RVector2(size.GetX() - 25.f, 5.f);
+		RText close_text("X", 20.f);
+		close_button_ = std::make_shared<TextButton>(close_pos,
+			[this]() {
+				should_close_ = true;
+			},
+			close_text,
+			false);
+
+		drawables_.push_back(close_button_);
+	}
+
+	std::vector<std::shared_ptr<Drawable>>& Window::GetDrawables() {
+		return drawables_;
+	}
+}

--- a/src/gui/window.h
+++ b/src/gui/window.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <Color.hpp>
+#include <Text.hpp>
+#include <Vector2.hpp>
+
+#include "../drawable/button/text_button.h"
+#include "../drawable/rectangle.h"
+#include "../drawable/text.h"
+#include "../drawable/drawable.h"
+
+namespace fow {
+	class Window {
+	public:
+		Window(RVector2 pos, RVector2 size);
+		Window(RVector2 pos, RVector2 size, const RText& text);
+
+		std::vector<std::shared_ptr<Drawable>>& GetDrawables();
+
+		bool ShouldClose() const {
+			return should_close_;
+		}
+
+		void InitWindow(RVector2 position, RVector2 size, const std::optional<RText>& text);
+
+		std::vector<std::shared_ptr<Drawable>> drawables_;
+		std::shared_ptr<TextButton> close_button_;
+		bool should_close_ = false;
+	};
+
+}

--- a/src/match/match_screen.cc
+++ b/src/match/match_screen.cc
@@ -24,6 +24,7 @@
 #include "../drawable/text.h"
 #include "../drawable/texture_manager.h"
 #include "../structs/vector2i.h"
+
 #include "match.h"
 #include "player.h"
 #include "targets/units/unit.h"
@@ -121,6 +122,7 @@ void MatchScreen::Update() {
 
   camera_ = player.GetCamera();
   PlacePlayerButtons(player);
+  UpdateTileInfoWindow(player);
 
   if (auto& unit = player.GetSelectedUnit(); unit) {
     ShowSelectedUnitHud(unit, match_->GetUnitManager());
@@ -333,6 +335,45 @@ void MatchScreen::PlacePossibleTiles(Player& player) {
   for (auto& drawable : draw_later) {
     PlaceDrawable(drawable);
   }
+}
+
+void MatchScreen::UpdateTileInfoWindow(Player& player) {
+    Vector2I selected = player.GetSelectedTilePosition();
+
+    if (selected != last_selected_tile_) {
+        tile_info_window_.reset();
+
+        if (selected.x >= 0 && selected.y >= 0) {
+            const auto& map = match_->GetMap();
+            const auto& tiles = map->GetTiles();
+            auto terrain = tiles[selected.x][selected.y].GetTerrain();
+            TerrainModifiers mods = terrain->GetModifiers();
+            std::string info = map->GetTerrainManager().GetName(terrain->GetType());
+
+            info += "\nAttack bonus: " + std::format("{:+.0f}%", mods.attack_bonus * 100);
+            info += "\nDefense bonus: " + std::format("{:+.0f}%", mods.defense_bonus * 100);
+            info += "\nMovement cost: " + std::format("{:.1f}", mods.movement_cost);
+
+            RRectangle area = player.GetTileArea(selected);
+            RVector2 center = area.GetPosition() + area.GetSize() / 2.f;
+            RVector2 screen_center = camera_->GetWorldToScreen(center);
+            RVector2 size = { 220.f, 120.f };
+            RVector2 pos = screen_center + size / 12.f;
+            tile_info_window_ = std::make_unique<Window>(pos, size, RText(info, 20.f));
+        }
+
+        last_selected_tile_ = selected;
+    }
+
+    if (tile_info_window_) {
+        auto& drawables = tile_info_window_->GetDrawables();
+        for (auto& drawable : drawables) {
+            PlaceDrawable(drawable, true);
+        }
+        if (tile_info_window_->ShouldClose()) {
+            tile_info_window_.reset();
+        }
+    }
 }
 
 void MatchScreen::ShowSelectedUnitHud(const std::shared_ptr<Unit>& unit, const UnitManager& unit_manager) {

--- a/src/match/match_screen.h
+++ b/src/match/match_screen.h
@@ -8,6 +8,9 @@
 #include "match.h"
 #include "player.h"
 #include "targets/units/unit.h"
+#include "../structs/vector2i.h"
+#include "../gui/window.h"
+#include "../structs/vector2i.h"
 #include <Camera2D.hpp>
 
 namespace fow {
@@ -28,6 +31,7 @@ private:
   void PlaceProbabilityMap(Player& player);
   void PlacePossibleTiles(Player& player);
 
+  void UpdateTileInfoWindow(Player& player);
   void ShowSelectedUnitHud(const std::shared_ptr<Unit>& unit, const UnitManager& unit_manager);
 
   void InitMatch();
@@ -36,6 +40,8 @@ private:
 
   std::unique_ptr<ComplexDrawable> selected_unit_hud_;
   std::unique_ptr<ComplexDrawable> panel_hud_;
+  std::unique_ptr<Window> tile_info_window_;
+  Vector2I last_selected_tile_{ -2, -2 };
 
   std::unique_ptr<Match> match_;
   Input input;

--- a/src/match/player.cc
+++ b/src/match/player.cc
@@ -448,6 +448,10 @@ void Player::ResetUnitsMovementPoints() {
   }
 }
 
+RRectangle Player::GetTileArea(Vector2I position) const {
+    return render_map_[position.x][position.y]->GetArea();
+}
+
 void Player::UpdatePossibleTiles(const std::unique_ptr<Map>& map) {
   ClearPossibleTiles();
 

--- a/src/match/player.h
+++ b/src/match/player.h
@@ -26,6 +26,8 @@ public:
   void AddUnit(Vector2I position, UnitType unit_type, const UnitManager& unit_manager);
   void SetSelectedUnit(std::shared_ptr<Unit> unit, const std::unique_ptr<Map>& map = nullptr);
   const std::shared_ptr<Unit>& GetSelectedUnit() const { return selected_unit_; }
+  Vector2I GetSelectedTilePosition() const { return selected_tile_position_; }
+  RRectangle GetTileArea(Vector2I position) const;
   void ClearSelectedTile();
   void ClearActionTile();
 


### PR DESCRIPTION
Add a functionality for displaying an in-game window with tile info window as an example.

<img width="461" height="229" alt="image" src="https://github.com/user-attachments/assets/5e926978-8ac7-40eb-9164-4ce3184e6761" />
